### PR TITLE
Added a iterative Common Lisp implementation.

### DIFF
--- a/fibonacci.lisp
+++ b/fibonacci.lisp
@@ -1,0 +1,11 @@
+
+(defun fib (limit)
+  (do* ((last 1 current)
+        (current 1 next)
+        (next 1 (+ current last))
+        (res '(0) (nconc res (list current))))
+     ((> next limit) res))
+)
+
+(dolist (x (fib 1000))
+  (format T "~d " x))


### PR DESCRIPTION
Hi, 

just for fun I added a very short and quick Common Lisp solution. 
I tweaked it to generate exactly your desired output. Actually the correct sequence would be: 
1 1 2 3 5 8 13 21 34 55 89 144 233 377 610 987 
so one needs a trick to eliminate the second 1. I did not check the other languages if they are doing this the way you want.

Regards,
Michael
